### PR TITLE
for #5: add breadcrumb pref for future heartbeat

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -76,6 +76,7 @@ class StudyLifeCycleHandler {
    */
   enableFeature(studyInfo) {
     console.log("Enabling experiment", studyInfo);
+    browser.prefs.setBoolPref("extensions.cookie-restrictions-shield_mozilla.org.wasEnabled", true);
     const { delayInMinutes } = studyInfo;
     if (delayInMinutes !== undefined) {
       const alarmName = `${browser.runtime.id}:studyExpiration`;


### PR DESCRIPTION
Though, which I checked for this in `about:preferences`, I think I realized we could just use the presence of the `extensions.cookie-restrictions-shield_mozilla.org.test.variationName` pref for the same purpose?