### PR TITLE
Report if the user adds or removes an exception for this page 

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -52,7 +52,7 @@ telemetry: {
       "page_reloaded":"true",
       "page_reloaded_survey":"1",
       "user_reported_page_breakage":"false",
-      "user_added_exception":"false",
+      "user_toggled_exception": "0",
       "num_EvalError":"0",
       "num_InternalError":"0",
       "num_RangeError":"0",

--- a/src/feature.js
+++ b/src/feature.js
@@ -5,6 +5,10 @@ const SURVEY_SHOWN = 1;
 const SURVEY_PAGE_BROKEN = 2;
 const SURVEY_PAGE_NOT_BROKEN = 3;
 
+// Constants for the user_toggled_exception telemetry probe
+const PROTECTION_DISABLED = 1;
+const PROTECTION_ENABLED = 2;
+
 class Feature {
   constructor() {}
 
@@ -116,12 +120,12 @@ class Feature {
       }
     );
 
-    browser.trackers.onAddException.addListener(tabId => {
+    browser.trackers.onToggleException.addListener((tabId, toggleValue) => {
       if (tabId < 0) {
         return;
       }
       const tabInfo = TabRecords.getOrInsertTabInfo(tabId);
-      tabInfo.telemetryPayload.user_added_exception = true;
+      tabInfo.telemetryPayload.user_toggled_exception = toggleValue ? PROTECTION_DISABLED : PROTECTION_ENABLED;
     });
 
     // Watch for the user pressing the "Yes this page is broken"

--- a/src/privileged/trackers/schema.json
+++ b/src/privileged/trackers/schema.json
@@ -56,11 +56,12 @@
         ]
       },
       {
-        "name": "onAddException",
+        "name": "onToggleException",
         "type": "function",
-        "description": "The user added this page to the tracking protection exception.",
+        "description": "The user has added or removed and exception for this page in tracking protection.",
         "parameters": [
-          {"type": "integer", "name": "tabId", "minimum": 0}
+          {"type": "integer", "name": "tabId", "minimum": 0},
+          {"type": "boolean", "name": "toggleValue"}
         ]
       }
     ]

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -24,7 +24,7 @@ window.TabRecords = {
       page_reloaded: false,
       page_reloaded_survey: 0,
       user_reported_page_breakage: false,
-      user_added_exception: false,
+      user_toggled_exception: 0,
       num_EvalError: 0,
       num_InternalError: 0,
       num_RangeError: 0,

--- a/test/functional/3-add-exception.js
+++ b/test/functional/3-add-exception.js
@@ -68,7 +68,7 @@ describe("add page exception button", function() {
     it("correctly records that the user added an exception for this page", async () => {
       const ping = studyPings[0];
       const attributes = ping.payload.data.attributes;
-      assert.equal(attributes.user_added_exception, "true", "user added exception is included in the ping");
+      assert.equal(attributes.user_toggled_exception, "1", "user added exception is included in the ping");
     });
 
     after(async () => {


### PR DESCRIPTION

- changes `user_added_exception` to `user_toggled_exception`
- uses int instead of bool so we can see turn on, and a turn off events, plus neutral.

Todo: update phd with details on the data sent
Fixes: #16.