### PR TITLE
Detect if there is a login form on page.

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -62,7 +62,8 @@ telemetry: {
       "num_URIError":"0",
       "num_SecurityError":"0",
       "browser_contentblocking_enabled": "true",
-      "privacy_trackingprotection_enabled": "true"
+      "privacy_trackingprotection_enabled": "true",
+      "login_form_on_page": "false"
     }
   }
 }

--- a/src/feature.js
+++ b/src/feature.js
@@ -68,6 +68,7 @@ class Feature {
         tabInfo.reloadCount = 0;
       }
 
+      tabInfo.telemetryPayload.login_form_on_page = data.login_form_on_page;
       tabInfo.telemetryPayload.page_reloaded = data.pageReloaded;
       for (const key in data.performanceEvents) {
         tabInfo.telemetryPayload[key] = data.performanceEvents[key];

--- a/src/privileged/trackers/framescript.js
+++ b/src/privileged/trackers/framescript.js
@@ -77,6 +77,8 @@ addEventListener("DOMContentLoaded", function(e) {
     if (docShell.document.numTrackersFound <= 0) {
       return;
     }
+    const passwordFields = content.document.querySelectorAll("input[type='password']");
+    telemetryData.login_form_on_page = !!passwordFields.length;
 
     telemetryData.trackersFound = docShell.document.numTrackersFound;
     telemetryData.trackersBlocked = docShell.document.numTrackersBlocked;

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -35,6 +35,7 @@ window.TabRecords = {
       num_SecurityError: 0,
       "browser_contentblocking_enabled": false,
       "privacy_trackingprotection_enabled": false,
+      "login_form_on_page": false,
     };
 
     return tabInfo;


### PR DESCRIPTION
- Identify if there is a password field on the page, and if so, assume there is a login. 
- Add `login_form_on_page` to telemetry