### PR TITLE
Record tracking protection exception state

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -65,6 +65,7 @@ telemetry: {
       "privacy_trackingprotection_enabled": "true",
       "login_form_on_page": "false",
       "embedded_social_login_script": "false",
+      "user_has_tracking_protection_exception": "false",
     }
   }
 }

--- a/src/feature.js
+++ b/src/feature.js
@@ -73,6 +73,8 @@ class Feature {
       }
       tabInfo.telemetryPayload.embedded_social_login_script = data.embedded_social_login_script;
       tabInfo.telemetryPayload.login_form_on_page = data.login_form_on_page;
+      tabInfo.telemetryPayload.user_has_tracking_protection_exception =
+        data.user_has_tracking_protection_exception;
       tabInfo.telemetryPayload.page_reloaded = data.pageReloaded;
       for (const key in data.performanceEvents) {
         tabInfo.telemetryPayload[key] = data.performanceEvents[key];

--- a/src/privileged/trackers/api.js
+++ b/src/privileged/trackers/api.js
@@ -90,12 +90,19 @@ this.trackers = class extends ExtensionAPI {
         },
         async pageBeforeUnloadCallback(e) {
           const tabId = tabTracker.getBrowserTabId(e.target);
+          let uri;
           try {
+            uri = Services.io.newURI(e.data.telemetryData.completeLocation);
+            // Browser is never private, so type can always be "trackingprotection"
             e.data.telemetryData.etld =
               Services.eTLD.getBaseDomainFromHost(e.data.telemetryData.hostname);
           } catch (error) {
             return;
           }
+          e.data.telemetryData.user_has_tracking_protection_exception =
+            Services.perms.testExactPermission(uri, "trackingprotection") === Services.perms.ALLOW_ACTION;
+          e.data.telemetryData.completeLocation = null;
+          uri = null;
           trackersEventEmitter.emitPageBeforeUnload(tabId, e.data.telemetryData);
         },
         async pageUnloadCallback(e) {

--- a/src/privileged/trackers/framescript.js
+++ b/src/privileged/trackers/framescript.js
@@ -58,6 +58,7 @@ addEventListener("DOMContentLoaded", function(e) {
   content.window.addEventListener("beforeunload", () => {
     const passwordFields = content.document.querySelectorAll("input[type='password']");
     telemetryData.login_form_on_page = !!passwordFields.length;
+    telemetryData.completeLocation = content.location.href;
 
     telemetryData.trackersFound = docShell.document.numTrackersFound;
     telemetryData.trackersBlocked = docShell.document.numTrackersBlocked;

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -37,6 +37,7 @@ window.TabRecords = {
       "privacy_trackingprotection_enabled": false,
       "login_form_on_page": false,
       "embedded_social_login_script": false,
+      "user_has_tracking_protection_exception": false,
     };
 
     return tabInfo;

--- a/test/functional/1-telemetry.js
+++ b/test/functional/1-telemetry.js
@@ -214,4 +214,32 @@ describe("telemetry", function() {
       assert.isEmpty(studyPings, "no study pings present");
     });
   });
+
+  describe("records the correct value if a user has set an exception", function() {
+    before(async () => {
+      const time = Date.now();
+      driver.setContext(Context.CONTENT);
+      await driver.get("https://itisatrap.org/firefox/its-a-tracker.html");
+      await driver.sleep(500);
+      await driver.navigate().refresh();
+      await driver.sleep(500);
+      studyPings = await utils.telemetry.getShieldPingsAfterTimestamp(
+        driver,
+        time,
+      );
+      studyPings = studyPings.filter(ping => ping.type === "shield-study-addon");
+    });
+
+    it("correctly records if the user has set a tracking protection exception on the page", async () => {
+      it.skip("This depends on platform support, this will currently only record false");
+      const ping = studyPings[0];
+      const attributes = ping.payload.data.attributes;
+      const value = await driver.executeScript(`
+        let uri = Services.io.newURI("https://itisatrap.org/firefox/its-a-tracker.html");
+        return Services.perms.testExactPermission(uri, "trackingprotection") === Services.perms.ALLOW_ACTION;
+      `);
+
+      assert.equal(attributes.user_has_tracking_protection_exception, value.toString(), "user_has_tracking_protection_exception is recorded, and equals the actual setting");
+    });
+  });
 });


### PR DESCRIPTION
this records the current state of if the user has set a tracking protection exception for this page.

Imported from https://github.com/mozilla/FastBlockShield/pull/88/files

Fixes: #7 