### PR TITLE
Detect embedded social login scripts.

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -63,7 +63,8 @@ telemetry: {
       "num_SecurityError":"0",
       "browser_contentblocking_enabled": "true",
       "privacy_trackingprotection_enabled": "true",
-      "login_form_on_page": "false"
+      "login_form_on_page": "false",
+      "embedded_social_login_script": "false",
     }
   }
 }

--- a/src/feature.js
+++ b/src/feature.js
@@ -71,7 +71,7 @@ class Feature {
         tabInfo.surveyShown = false;
         tabInfo.reloadCount = 0;
       }
-
+      tabInfo.telemetryPayload.embedded_social_login_script = data.embedded_social_login_script;
       tabInfo.telemetryPayload.login_form_on_page = data.login_form_on_page;
       tabInfo.telemetryPayload.page_reloaded = data.pageReloaded;
       for (const key in data.performanceEvents) {

--- a/src/privileged/trackers/framescript.js
+++ b/src/privileged/trackers/framescript.js
@@ -83,6 +83,22 @@ addEventListener("DOMContentLoaded", function(e) {
     telemetryData.trackersFound = docShell.document.numTrackersFound;
     telemetryData.trackersBlocked = docShell.document.numTrackersBlocked;
 
+    // Find all scripts on the page.
+    const scripts = Array.prototype.slice
+      .apply(content.document.querySelectorAll("script"))
+      .filter(s => s.src)
+      .map(s => s.src);
+    // Find if any of the scripts are identified social login scripts.
+    telemetryData.embedded_social_login_script = scripts.some(src => {
+      return src.includes("platform.twitter.com/widgets.js") ||
+             /connect\.facebook\.net\/.*\/(all|sdk)\.js/.test(src) ||
+             src.includes("apis.google.com/js/platform.js") ||
+             src.includes("platform.linkedin.com/in.js") ||
+             src.includes("www.paypalobjects.com/js/external/api.js") ||
+             src.includes("api-cdn.amazon.com/sdk/login1.js") ||
+             src.includes("api.instagram.com/oauth/authorize/");
+    });
+
     sendAsyncMessage("beforeunload", {telemetryData});
   }, {once: true});
 

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -36,6 +36,7 @@ window.TabRecords = {
       "browser_contentblocking_enabled": false,
       "privacy_trackingprotection_enabled": false,
       "login_form_on_page": false,
+      "embedded_social_login_script": false,
     };
 
     return tabInfo;


### PR DESCRIPTION
- Detects if a page is using an emedded login script from google, twitter, facebook, paypal, linkedin, amazon or instagram. 
-  Adds "embedded_social_login_script" to the telemetry ping.

test: 
https://developer.twitter.com/en/docs/basics/authentication/guides/single-user.html
(I've only found one site so far)

To discuss: 
This is very rarely use in the wild, is this the only type of social logins we want to detect or are we concerned with buttons and anchor tags that redirect to Oauth endpoints?

Fixes #15
