### PR TITLE
Really remove addon on disable or remove in about:addons (closes #106)

### DIFF
--- a/src/privileged/trackers/api.js
+++ b/src/privileged/trackers/api.js
@@ -1,8 +1,9 @@
 "use strict";
 
-/* global ExtensionAPI, ExtensionCommon, ExtensionUtils, XPCOMUtils, Services */
+/* global AddonManager, ExtensionAPI, ExtensionCommon, ExtensionUtils, XPCOMUtils, Services */
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.defineModuleGetter(this, "AddonManager", "resource://gre/modules/AddonManager.jsm");
 
 /* eslint-disable-next-line no-var */
 var {EventManager, EventEmitter} = ExtensionCommon;
@@ -149,6 +150,28 @@ this.trackers = class extends ExtensionAPI {
 
         async init() {
           EveryWindow.registerCallback("set-content-listeners", this.setListeners.bind(this), this.unmount.bind(this));
+
+          // Listen for addon disabling or uninstall.
+          AddonManager.addAddonListener(this);
+        },
+
+        onUninstalling(addon) {
+          this.handleDisableOrUninstall(addon);
+        },
+
+        onDisabled(addon) {
+          this.handleDisableOrUninstall(addon);
+        },
+
+        handleDisableOrUninstall(addon) {
+          if (addon.id !== context.extension.id) {
+            return;
+          }
+
+          AddonManager.removeAddonListener(this);
+          // This is needed even for onUninstalling, because it nukes the addon
+          // from UI. If we don't do this, the user has a chance to "undo".
+          addon.uninstall();
         },
 
         onPageUnload: new EventManager(


### PR DESCRIPTION
When uninstalling or disabling the add-on, it must be permanently gone and not able to undo. 

Fixes: #44 