### PR TITLE
reverse button order to prevent false positives

### DIFF
--- a/src/privileged/popupNotification/api.js
+++ b/src/privileged/popupNotification/api.js
@@ -39,20 +39,20 @@ class PopupNotificationEventEmitter extends EventEmitter {
 
     const primaryAction =  {
       disableHighlight: true,
-      label: "Other Reason",
-      accessKey: "d",
+      label: "Page Was Broken",
+      accessKey: "f",
       callback: () => {
-        self.emit("page-not-broken", tabId);
+        const addExceptionButton = recentWindow.document.getElementById("tracking-action-unblock");
+        addExceptionButton.doCommand();
+        self.emit("page-broken", tabId);
       },
     };
     const secondaryActions =  [
       {
-        label: "Page Was Broken",
-        accessKey: "f",
+        label: "Other Reason",
+        accessKey: "d",
         callback: () => {
-          const addExceptionButton = recentWindow.document.getElementById("tracking-action-unblock");
-          addExceptionButton.doCommand();
-          self.emit("page-broken", tabId);
+          self.emit("page-not-broken", tabId);
         },
       },
     ];


### PR DESCRIPTION
esc button triggers secondary option.
To avoid false positives from the `esc` button, keeping the secondary option as the negative option is better. Cleared with mheubusch.