### PR TITLE
remove testing flag, adjust manifest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "prewatch": "npm run bundle-utils",
     "sign": "echo 'TBD, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1407757'",
     "start": "web-ext run --no-reload",
-    "test": "FIREFOX_BINARY=${FIREFOX_BINARY:-Nightly} ADDON_ZIP=./dist/mozilla_cookie_restrictions_user_study-1.0.0.zip mocha test/functional/ --bail",
+    "test": "FIREFOX_BINARY=${FIREFOX_BINARY:-Nightly} ADDON_ZIP=./dist/mozilla_cookie_restrictions_user_study-1.0.3.zip mocha test/functional/ --bail",
     "watch": "web-ext run"
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Mozilla Cookie Restrictions User Study",
   "description": "A Mozilla study created to learn the positive and negative effects of blocking tracking cookies.",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "manifest_version": 2,
   "applications": {
     "gecko": {

--- a/src/studySetup.js
+++ b/src/studySetup.js
@@ -31,7 +31,7 @@ const baseStudySetup = {
     // default false. Actually send pings.
     send: true,
     // Marks pings with testing=true.  Set flag to `true` before final release
-    removeTestingFlag: false,
+    removeTestingFlag: true,
   },
 
   // We don't have a survey at the ending


### PR DESCRIPTION
Fixes: #18 

This will now send telemetry pings without the testing flag.

I need to adjust the manifest version for each signed release - hence why it is done. 