### PR TITLE
only offer chance of popup if interaction has happened in the previou…

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -61,6 +61,10 @@ class Feature {
       const hash = await this.SHA256(userid + etld);
       tabInfo.telemetryPayload.etld = hash;
 
+      if (!tabInfo.previousPagesWereInteracted) {
+        return;
+      }
+
       // Show the user a survey if the page was reloaded.
       tabInfo.reloadCount++;
       this.possiblyShowNotification(tabInfo);
@@ -75,10 +79,12 @@ class Feature {
 
       const tabInfo = TabRecords.getOrInsertTabInfo(tabId);
 
+      tabInfo.previousPagesWereInteracted = data.previousPagesWereInteracted || tabInfo.previousPagesWereInteracted;
       // Reset survey count when no longer refreshing
       if (!data.page_reloaded) {
         tabInfo.surveyShown = false;
         tabInfo.reloadCount = 0;
+        tabInfo.previousPagesWereInteracted = false;
       }
       tabInfo.telemetryPayload.embedded_social_script = data.embedded_social_script;
       tabInfo.telemetryPayload.login_form_on_page = data.login_form_on_page;

--- a/src/privileged/trackers/framescript.js
+++ b/src/privileged/trackers/framescript.js
@@ -50,7 +50,9 @@ addEventListener("DOMContentLoaded", function(e) {
     telemetryData.completeLocation = content.location.href;
     if (docShell && docShell.document) {
       telemetryData.num_blockable_trackers = docShell.document.numTrackersFound;
+      telemetryData.previousPagesWereInteracted = docShell.document.userHasInteracted;
     } else {
+      telemetryData.previousPagesWereInteracted = false;
       telemetryData.num_blockable_trackers = -1; // some sort of error here
     }
 

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -52,6 +52,7 @@ window.TabRecords = {
     tabInfo = {
       surveyShown: false,
       reloadCount: 0,
+      previousPagesWereInteracted: false,
     };
 
     this._tabs.set(tabId, tabInfo);


### PR DESCRIPTION
…s refreshes

If the user has interacted with the page - clicked, entered data into an input etc - then on the next refresh (and subsequent refreshes) they have a chance of seeing the popup.

This flag gets reset on a navigate event - then they need to interact again to receive a chance of seeing the popup.

note: It hasn't been fully decided if we'd like to take this route yet