### PR TITLE
Attach survey telemetry to the page it was connected to.

### DIFF
--- a/src/privileged/popupNotification/api.js
+++ b/src/privileged/popupNotification/api.js
@@ -42,8 +42,11 @@ class PopupNotificationEventEmitter extends EventEmitter {
       label: "Page Was Broken",
       accessKey: "f",
       callback: () => {
-        const addExceptionButton = recentWindow.document.getElementById("tracking-action-unblock");
-        addExceptionButton.doCommand();
+        const hasException = Services.perms.testExactPermissionFromPrincipal(recentWindow.gBrowser.contentPrincipal, "trackingprotection") === Services.perms.ALLOW_ACTION;
+        if (!hasException) {
+          const addExceptionButton = recentWindow.document.getElementById("tracking-action-unblock");
+          addExceptionButton.doCommand();
+        }
         self.emit("page-broken", tabId);
       },
     };

--- a/src/privileged/trackers/schema.json
+++ b/src/privileged/trackers/schema.json
@@ -26,7 +26,8 @@
         "type": "function",
         "description": "When the page unloads.",
         "parameters": [
-          {"type": "integer", "name": "tabId", "minimum": 0}
+          {"type": "integer", "name": "tabId", "minimum": 0},
+          {"type": "object", "name": "data"} 
         ]
       },
       {
@@ -46,21 +47,20 @@
         ]
       },
       {
-        "name": "onReload",
-        "type": "function",
-        "description": "This is called when we find a page that was reloaded.",
-        "parameters": [
-          {"type": "integer", "name": "tabId", "minimum": 0},
-          {"type": "string", "name": "etld"}
-        ]
-      },
-      {
         "name": "onToggleException",
         "type": "function",
         "description": "The user has added or removed and exception for this page in tracking protection.",
         "parameters": [
           {"type": "integer", "name": "tabId", "minimum": 0},
           {"type": "boolean", "name": "toggleValue"}
+        ]
+      },
+      {
+        "name": "onPageDOMContentLoaded",
+        "type": "function",
+        "description": "When the page has loaded the DOM.",
+        "parameters": [
+          {"type": "integer", "name": "tabId", "minimum": 0}
         ]
       }
     ]

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -50,6 +50,7 @@ window.TabRecords = {
     }
 
     tabInfo = {
+      payloadWaitingForSurvey: null,
       surveyShown: false,
       reloadCount: 0,
     };


### PR DESCRIPTION
based on https://github.com/mozilla/FastBlockShield/pull/124

This introduces a new attribute on the tabInfo called
`payloadWaitingForSurvey`, which keeps a payload that is currently held
back from sending because the user still needs to respond to the reload
survey.

- `payloadWaitingForSurvey` sends on interaction with the survey, or on the next page refresh if the survey did not show up.
- If there is a `payloadWaitingForSurvey` waiting to send, and you close the tab, you will see 2 payloads sent

note: My tests fail at `5-reload-doorhanger.js line 171`, though they failed for the other PR too - could someone double check this please.

fixes: #84 

apparently also:
fixes: #79